### PR TITLE
Infer qstat/qselect path from PBS_EXEC env variable

### DIFF
--- a/pbs/qstat.go
+++ b/pbs/qstat.go
@@ -120,7 +120,7 @@ func parseExecVNode(execVNode string) ([]jobperf.Node, error) {
 
 func qstatGetJob(jobID string) (*jobperf.Job, error) {
 	slog.Debug("fetching job by id", "jobID", jobID)
-	cmd := exec.Command("/opt/pbs/default/bin/qstat", "-xf", "-Fjson", jobID)
+	cmd := exec.Command(os.Getenv("PBS_EXEC") + "/bin/qstat", "-xf", "-Fjson", jobID)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()
@@ -220,7 +220,7 @@ type QSelectOptions struct {
 }
 
 func QSelectJobs(opt QSelectOptions) ([]string, error) {
-	cmd := exec.Command("/opt/pbs/default/bin/qselect", "-s", opt.State)
+	cmd := exec.Command(os.Getenv("PBS_EXEC") + "/bin/qselect", "-s", opt.State)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	err := cmd.Run()


### PR DESCRIPTION
Fixes #1 for our site, but may need to be tested against other PBS installations.